### PR TITLE
Refactor server.py by removing redundant comments for clarity

### DIFF
--- a/server.py
+++ b/server.py
@@ -3,13 +3,11 @@ import os
 import uvicorn
 
 if __name__ == "__main__":
-    # Get port from environment or use default
     port = int(os.environ.get("PORT", 8000))
 
-    # Run the server
     uvicorn.run(
         "app.api:app",
         host="0.0.0.0",
         port=port,
-        reload=True,  # Enable auto-reload during development
+        reload=True,
     )


### PR DESCRIPTION
This pull request includes a minor change to the `server.py` file. The changes involve removing some comments that explained the code and a redundant comment on the `reload` parameter.

Changes to `server.py`:

* Removed comments explaining the port retrieval from the environment and the server run command.
* Removed a redundant comment on the `reload` parameter in the `uvicorn.run` method.